### PR TITLE
Netbios name resolving

### DIFF
--- a/MultiFactor.Ldap.Adapter/App.config
+++ b/MultiFactor.Ldap.Adapter/App.config
@@ -53,9 +53,9 @@
     <!--Windows Service settings -->
     <add key="service-unit-name" value="MFLdapAdapter" />
     <add key="service-display-name" value="MultiFactor Ldap Adapter" />
-	
-	<!--certificate password leave empty or null for certificate without password-->
-	<!--<add key="certificate-password" value="XXXXXX"/>-->
+
+    <!--certificate password leave empty or null for certificate without password-->
+    <!--<add key="certificate-password" value="XXXXXX"/>-->
     <!--<add key="transform-ldap-identity" value="upn"/>-->
   </appSettings>
   <runtime>

--- a/MultiFactor.Ldap.Adapter/App.config
+++ b/MultiFactor.Ldap.Adapter/App.config
@@ -56,7 +56,7 @@
 	
 	<!--certificate password leave empty or null for certificate without password-->
 	<!--<add key="certificate-password" value="XXXXXX"/>-->
-
+    <!--<add key="transform-ldap-identity" value="upn"/>-->
   </appSettings>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">

--- a/MultiFactor.Ldap.Adapter/Configuration/ClientConfiguration.cs
+++ b/MultiFactor.Ldap.Adapter/Configuration/ClientConfiguration.cs
@@ -2,7 +2,7 @@
 //Please see licence at 
 //https://github.com/MultifactorLab/MultiFactor.Ldap.Adapter/blob/main/LICENSE.md
 
-using MultiFactor.Ldap.Adapter.Core.NameResolve;
+using MultiFactor.Ldap.Adapter.Core.NameResolving;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/MultiFactor.Ldap.Adapter/Configuration/ClientConfiguration.cs
+++ b/MultiFactor.Ldap.Adapter/Configuration/ClientConfiguration.cs
@@ -2,6 +2,7 @@
 //Please see licence at 
 //https://github.com/MultifactorLab/MultiFactor.Ldap.Adapter/blob/main/LICENSE.md
 
+using MultiFactor.Ldap.Adapter.Core.NameResolve;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -20,6 +21,7 @@ namespace MultiFactor.Ldap.Adapter.Configuration
 
             LoadActiveDirectoryNestedGroups = true;
             UserNameTransformRules = new List<UserNameTransformRulesElement>();
+            TransformLdapIdentity = LdapIdentityFormat.None;
         }
 
         /// <summary>
@@ -79,9 +81,8 @@ namespace MultiFactor.Ldap.Adapter.Configuration
         /// API Secret
         /// </summary>
         public string MultifactorApiSecret { get; set; }
-
+        public LdapIdentityFormat TransformLdapIdentity { get; set; }
         public AuthenticatedClientCacheConfig AuthenticationCacheLifetime { get; internal set; }
-
 
         public bool CheckUserGroups()
         {

--- a/MultiFactor.Ldap.Adapter/Configuration/ServiceConfiguration.cs
+++ b/MultiFactor.Ldap.Adapter/Configuration/ServiceConfiguration.cs
@@ -3,6 +3,7 @@
 //https://github.com/MultifactorLab/MultiFactor.Ldap.Adapter/blob/main/LICENSE.md
 
 using MultiFactor.Ldap.Adapter.Core;
+using MultiFactor.Ldap.Adapter.Core.NameResolve;
 using NetTools;
 using Serilog;
 using System;
@@ -104,7 +105,6 @@ namespace MultiFactor.Ldap.Adapter.Configuration
             var apiTimeoutSetting = appSettings.Settings["multifactor-api-timeout"]?.Value;
             var logLevelSetting = appSettings.Settings["logging-level"]?.Value;
             var certificatePassword = appSettings.Settings["certificate-password"]?.Value;
-
             if (string.IsNullOrEmpty(apiUrlSetting))
             {
                 throw new Exception("Configuration error: 'multifactor-api-url' element not found");
@@ -209,7 +209,7 @@ namespace MultiFactor.Ldap.Adapter.Configuration
             var activeDirectory2FaBypassGroupSetting                = appSettings.Settings["active-directory-2fa-bypass-group"]?.Value;
             var bypassSecondFactorWhenApiUnreachableSetting         = appSettings.Settings["bypass-second-factor-when-api-unreachable"]?.Value;
             var loadActiveDirectoryNestedGroupsSettings             = appSettings.Settings["load-active-directory-nested-groups"]?.Value;
-
+            var transformLdapIdentity                               = appSettings.Settings["transform-ldap-identity"]?.Value;
 
             if (string.IsNullOrEmpty(ldapServerSetting))
             {
@@ -230,6 +230,9 @@ namespace MultiFactor.Ldap.Adapter.Configuration
                 LdapServer = ldapServerSetting,
                 MultifactorApiKey = multifactorApiKeySetting,
                 MultifactorApiSecret = multifactorApiSecretSetting,
+                TransformLdapIdentity = string.IsNullOrEmpty(transformLdapIdentity) 
+                    ? LdapIdentityFormat.None
+                    : (LdapIdentityFormat)Enum.Parse(typeof(LdapIdentityFormat), transformLdapIdentity, true)
             };
 
             if (!string.IsNullOrEmpty(serviceAccountsSetting))

--- a/MultiFactor.Ldap.Adapter/Configuration/ServiceConfiguration.cs
+++ b/MultiFactor.Ldap.Adapter/Configuration/ServiceConfiguration.cs
@@ -3,7 +3,7 @@
 //https://github.com/MultifactorLab/MultiFactor.Ldap.Adapter/blob/main/LICENSE.md
 
 using MultiFactor.Ldap.Adapter.Core;
-using MultiFactor.Ldap.Adapter.Core.NameResolve;
+using MultiFactor.Ldap.Adapter.Core.NameResolving;
 using NetTools;
 using Serilog;
 using System;

--- a/MultiFactor.Ldap.Adapter/Core/NameResolving/LdapIdentityFormat.cs
+++ b/MultiFactor.Ldap.Adapter/Core/NameResolving/LdapIdentityFormat.cs
@@ -1,0 +1,12 @@
+﻿namespace MultiFactor.Ldap.Adapter.Core.NameResolve
+{
+    public enum LdapIdentityFormat
+    {
+        None = 0,
+        Upn = 1,
+        UidAndNetbios = 2, // uid@netbios
+        SamAccountName = 3,
+        NetBIOSAndUid = 4, // NETBIOS\uid
+        DistinguishedName = 5 
+    }
+}

--- a/MultiFactor.Ldap.Adapter/Core/NameResolving/LdapIdentityFormat.cs
+++ b/MultiFactor.Ldap.Adapter/Core/NameResolving/LdapIdentityFormat.cs
@@ -1,4 +1,4 @@
-﻿namespace MultiFactor.Ldap.Adapter.Core.NameResolve
+﻿namespace MultiFactor.Ldap.Adapter.Core.NameResolving
 {
     public enum LdapIdentityFormat
     {

--- a/MultiFactor.Ldap.Adapter/Core/NameResolving/NameResolverContext.cs
+++ b/MultiFactor.Ldap.Adapter/Core/NameResolving/NameResolverContext.cs
@@ -1,0 +1,10 @@
+﻿using MultiFactor.Ldap.Adapter.Services;
+
+namespace MultiFactor.Ldap.Adapter.Core.NameResolving
+{   
+    public class NameResolverContext
+    {
+        public NetbiosDomainName[] Domains;
+        public LdapProfile Profile;
+    }
+}

--- a/MultiFactor.Ldap.Adapter/Core/NameResolving/NameResolverService.cs
+++ b/MultiFactor.Ldap.Adapter/Core/NameResolving/NameResolverService.cs
@@ -1,0 +1,61 @@
+﻿using MultiFactor.Ldap.Adapter.Core.NameResolving;
+using MultiFactor.Ldap.Adapter.Core.NameResolving.NameTranslators;
+using Serilog;
+
+namespace MultiFactor.Ldap.Adapter.Core.NameResolve
+{
+    public class NameResolverService
+    {
+        private ILogger _logger;
+
+        public NameResolverService(ILogger logger)
+        {
+            _logger = logger;
+        }
+
+        public string Resolve(NameResolverContext context, string name, LdapIdentityFormat to)
+        {
+            var from = NameTypeDetector.GetType(name);
+            if(from == null)
+            {
+                return name;
+            }
+
+            var resolver = GetTranslator(context, (LdapIdentityFormat)from, to);
+            if(resolver == null)
+            {
+                return name;
+            }
+            return resolver.Translate(context, name);
+        }
+
+
+        public INameTranslator GetTranslator(NameResolverContext context, LdapIdentityFormat from, LdapIdentityFormat to)
+        {
+            if (from == LdapIdentityFormat.UidAndNetbios && to  == LdapIdentityFormat.Upn)
+            {
+                return new sAMAccountNameAndNetbiosToUpnNameTranslator();
+            }
+            else if (from == LdapIdentityFormat.NetBIOSAndUid && to == LdapIdentityFormat.Upn)
+            {
+                return new NetbiosToUpnNameTranslator();
+            }
+            else if (from == LdapIdentityFormat.DistinguishedName && to == LdapIdentityFormat.Upn)
+            {
+                return new DistinguishedNameToUpnTranslator();
+            }
+            // There are a case when sAMAccountName@domain.local looks exactly like UPN
+            // Let's try an UPN we got from the profile
+            if (from == LdapIdentityFormat.Upn && to == LdapIdentityFormat.Upn && context.Profile != null)
+            {
+                return new UpnFromProfileNameTranslator();
+            }
+            if(from == LdapIdentityFormat.SamAccountName && to == LdapIdentityFormat.Upn)
+            {
+                return new sAMAccountNameToUpnNameTranslator();
+            }
+            _logger.Error($"Suitable username format was not found");
+            return null;
+        }
+    }
+}

--- a/MultiFactor.Ldap.Adapter/Core/NameResolving/NameResolverService.cs
+++ b/MultiFactor.Ldap.Adapter/Core/NameResolving/NameResolverService.cs
@@ -2,7 +2,7 @@
 using MultiFactor.Ldap.Adapter.Core.NameResolving.NameTranslators;
 using Serilog;
 
-namespace MultiFactor.Ldap.Adapter.Core.NameResolve
+namespace MultiFactor.Ldap.Adapter.Core.NameResolving
 {
     public class NameResolverService
     {

--- a/MultiFactor.Ldap.Adapter/Core/NameResolving/NameTranslators/DistinguishedNameToUpnTranslator.cs
+++ b/MultiFactor.Ldap.Adapter/Core/NameResolving/NameTranslators/DistinguishedNameToUpnTranslator.cs
@@ -1,0 +1,16 @@
+﻿using System.Text.RegularExpressions;
+
+namespace MultiFactor.Ldap.Adapter.Core.NameResolving.NameTranslators
+{
+    public class DistinguishedNameToUpnTranslator : INameTranslator
+    {
+        public string Translate(NameResolverContext nameTranslatorContext, string from)
+        {
+            if (nameTranslatorContext.Profile != null)
+            {
+                return nameTranslatorContext.Profile.Upn;
+            }
+            return from;
+        }
+    }
+}

--- a/MultiFactor.Ldap.Adapter/Core/NameResolving/NameTranslators/INameTranslator.cs
+++ b/MultiFactor.Ldap.Adapter/Core/NameResolving/NameTranslators/INameTranslator.cs
@@ -1,0 +1,7 @@
+﻿namespace MultiFactor.Ldap.Adapter.Core.NameResolving.NameTranslators
+{
+    public interface INameTranslator
+    {
+        string Translate(NameResolverContext context, string from);
+    }
+}

--- a/MultiFactor.Ldap.Adapter/Core/NameResolving/NameTranslators/NetbiosToUpnNameTranslator.cs
+++ b/MultiFactor.Ldap.Adapter/Core/NameResolving/NameTranslators/NetbiosToUpnNameTranslator.cs
@@ -1,0 +1,26 @@
+﻿using System.Text.RegularExpressions;
+
+namespace MultiFactor.Ldap.Adapter.Core.NameResolving.NameTranslators
+{
+    public class NetbiosToUpnNameTranslator : INameTranslator
+    {
+        public string Translate(NameResolverContext nameTranslatorContext, string from)
+        {
+            if(nameTranslatorContext.Profile != null)
+            {
+                return nameTranslatorContext.Profile.Upn;
+            }
+
+            foreach (var domain in nameTranslatorContext.Domains)
+            {
+                var regex = new Regex("^" + domain.NetbiosName.ToLower() + "\\\\", RegexOptions.IgnoreCase);
+                if (regex.IsMatch(from))
+                {
+                    var result = regex.Replace(from + "@" + domain.Domain.ToLower(), "");
+                    return result;
+                }
+            }
+            return from;
+        }
+    }
+}

--- a/MultiFactor.Ldap.Adapter/Core/NameResolving/NameTranslators/UpnFromProfileNameTranslator.cs
+++ b/MultiFactor.Ldap.Adapter/Core/NameResolving/NameTranslators/UpnFromProfileNameTranslator.cs
@@ -1,0 +1,15 @@
+﻿
+namespace MultiFactor.Ldap.Adapter.Core.NameResolving.NameTranslators
+{
+    public class UpnFromProfileNameTranslator : INameTranslator
+    {
+        public string Translate(NameResolverContext nameResolverContext, string from)
+        {
+            if (nameResolverContext.Profile != null)
+            {
+                return nameResolverContext.Profile.Upn;
+            }
+            return from;
+        }
+    }
+}

--- a/MultiFactor.Ldap.Adapter/Core/NameResolving/NameTranslators/sAMAccountNameAndNetbiosToUpnNameTranslator.cs
+++ b/MultiFactor.Ldap.Adapter/Core/NameResolving/NameTranslators/sAMAccountNameAndNetbiosToUpnNameTranslator.cs
@@ -1,0 +1,25 @@
+﻿using System.Text.RegularExpressions;
+
+namespace MultiFactor.Ldap.Adapter.Core.NameResolving.NameTranslators
+{
+    public class sAMAccountNameAndNetbiosToUpnNameTranslator : INameTranslator
+    {
+        public string Translate(NameResolverContext nameTranslatorContext, string from)
+        {
+            if (nameTranslatorContext.Profile != null)
+            {
+                return nameTranslatorContext.Profile.Upn;
+            }
+            foreach(var domain in nameTranslatorContext.Domains)
+            {
+                var regex = new Regex("@" + domain.NetbiosName.ToLower() + "$", RegexOptions.IgnoreCase);
+                if(regex.IsMatch(from))
+                {
+                    var result = regex.Replace(from, "@" + domain.Domain.ToLower());
+                    return result;
+                }
+            }
+            return from;
+        }
+    }
+}

--- a/MultiFactor.Ldap.Adapter/Core/NameResolving/NameTranslators/sAMAccountNameToUpnNameTranslator.cs
+++ b/MultiFactor.Ldap.Adapter/Core/NameResolving/NameTranslators/sAMAccountNameToUpnNameTranslator.cs
@@ -1,0 +1,16 @@
+﻿using System.Text.RegularExpressions;
+
+namespace MultiFactor.Ldap.Adapter.Core.NameResolving.NameTranslators
+{
+    public class sAMAccountNameToUpnNameTranslator : INameTranslator
+    {
+        public string Translate(NameResolverContext nameTranslatorContext, string from)
+        {
+            if (nameTranslatorContext.Profile != null)
+            {
+                return nameTranslatorContext.Profile.Upn;
+            }
+            return from;
+        }
+    }
+}

--- a/MultiFactor.Ldap.Adapter/Core/NameResolving/NameTypeDetector.cs
+++ b/MultiFactor.Ldap.Adapter/Core/NameResolving/NameTypeDetector.cs
@@ -2,7 +2,7 @@
 using System.Linq;
 using System.Text.RegularExpressions;
 
-namespace MultiFactor.Ldap.Adapter.Core.NameResolve
+namespace MultiFactor.Ldap.Adapter.Core.NameResolving
 {
     public class NameTypeDetector
     {

--- a/MultiFactor.Ldap.Adapter/Core/NameResolving/NameTypeDetector.cs
+++ b/MultiFactor.Ldap.Adapter/Core/NameResolving/NameTypeDetector.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace MultiFactor.Ldap.Adapter.Core.NameResolve
+{
+    public class NameTypeDetector
+    {
+        public static LdapIdentityFormat? GetType(string name)
+        {
+            if (name.Contains('\\'))
+            {
+                return LdapIdentityFormat.NetBIOSAndUid;
+            }
+            if (name.IndexOf("CN=", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                return LdapIdentityFormat.DistinguishedName;
+            }
+            var domainRegex = new Regex("^[^@]+@(.+)$");
+            var domainMatch = domainRegex.Match(name);
+            if (!domainMatch.Success || domainMatch.Groups.Count < 2)
+            {
+                return LdapIdentityFormat.SamAccountName;
+            }
+            return domainMatch.Groups[1].Value.Count(x => x == '.') == 0 
+                ? LdapIdentityFormat.UidAndNetbios
+                : LdapIdentityFormat.Upn;
+        } 
+    }
+}

--- a/MultiFactor.Ldap.Adapter/Core/NameResolving/NetbiosDomainName.cs
+++ b/MultiFactor.Ldap.Adapter/Core/NameResolving/NetbiosDomainName.cs
@@ -1,0 +1,8 @@
+﻿namespace MultiFactor.Ldap.Adapter.Core.NameResolving
+{
+    public class NetbiosDomainName
+    {
+        public string Domain;
+        public string NetbiosName;
+    }
+}

--- a/MultiFactor.Ldap.Adapter/Extensions/ServiceCollectionExtensions.cs
+++ b/MultiFactor.Ldap.Adapter/Extensions/ServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using MultiFactor.Ldap.Adapter.Configuration;
+using MultiFactor.Ldap.Adapter.Core.NameResolve;
 using MultiFactor.Ldap.Adapter.Server;
 using MultiFactor.Ldap.Adapter.Services;
 using MultiFactor.Ldap.Adapter.Services.Caching;
@@ -73,7 +74,7 @@ namespace MultiFactor.Ldap.Adapter.Extensions
             services.AddSingleton<AuthenticatedClientCache>();
             services.AddSingleton<MultiFactorApiClient>();
             services.AddHttpClientWithProxy();
-
+            services.AddTransient<NameResolverService>();
             services.AddSingleton<AdapterService>();
         }
 

--- a/MultiFactor.Ldap.Adapter/Extensions/ServiceCollectionExtensions.cs
+++ b/MultiFactor.Ldap.Adapter/Extensions/ServiceCollectionExtensions.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using MultiFactor.Ldap.Adapter.Configuration;
-using MultiFactor.Ldap.Adapter.Core.NameResolve;
+using MultiFactor.Ldap.Adapter.Core.NameResolving;
 using MultiFactor.Ldap.Adapter.Server;
 using MultiFactor.Ldap.Adapter.Services;
 using MultiFactor.Ldap.Adapter.Services.Caching;

--- a/MultiFactor.Ldap.Adapter/MultiFactor.Ldap.Adapter.csproj
+++ b/MultiFactor.Ldap.Adapter/MultiFactor.Ldap.Adapter.csproj
@@ -206,6 +206,17 @@
     <Compile Include="Core\LdapPartialAttribute.cs" />
     <Compile Include="Core\LdapResult.cs" />
     <Compile Include="Core\LdapResultAttribute.cs" />
+    <Compile Include="Core\NameResolving\LdapIdentityFormat.cs" />
+    <Compile Include="Core\NameResolving\NameResolverContext.cs" />
+    <Compile Include="Core\NameResolving\NameResolverService.cs" />
+    <Compile Include="Core\NameResolving\NameTranslators\DistinguishedNameToUpnTranslator.cs" />
+    <Compile Include="Core\NameResolving\NameTranslators\INameTranslator.cs" />
+    <Compile Include="Core\NameResolving\NameTranslators\NetbiosToUpnNameTranslator.cs" />
+    <Compile Include="Core\NameResolving\NameTranslators\sAMAccountNameAndNetbiosToUpnNameTranslator.cs" />
+    <Compile Include="Core\NameResolving\NameTranslators\sAMAccountNameToUpnNameTranslator.cs" />
+    <Compile Include="Core\NameResolving\NameTranslators\UpnFromProfileNameTranslator.cs" />
+    <Compile Include="Core\NameResolving\NameTypeDetector.cs" />
+    <Compile Include="Core\NameResolving\NetbiosDomainName.cs" />
     <Compile Include="Core\Tag.cs" />
     <Compile Include="Core\TagClass.cs" />
     <Compile Include="Core\UniversalDataType.cs" />

--- a/MultiFactor.Ldap.Adapter/Server/LdapProxy.cs
+++ b/MultiFactor.Ldap.Adapter/Server/LdapProxy.cs
@@ -4,6 +4,8 @@
 
 using MultiFactor.Ldap.Adapter.Configuration;
 using MultiFactor.Ldap.Adapter.Core;
+using MultiFactor.Ldap.Adapter.Core.NameResolve;
+using MultiFactor.Ldap.Adapter.Core.NameResolving;
 using MultiFactor.Ldap.Adapter.Server.Authentication;
 using MultiFactor.Ldap.Adapter.Services;
 using Serilog;
@@ -37,12 +39,14 @@ namespace MultiFactor.Ldap.Adapter.Server
         private static readonly ConcurrentDictionary<string, string> _usersCn2Dn = new ConcurrentDictionary<string, string>();
 
         private readonly RandomWaiter _waiter;
+        private NameResolverService _nameResolverService;
 
         public LdapProxy(TcpClient clientConnection, Stream clientStream, TcpClient serverConnection, 
             Stream serverStream, ClientConfiguration clientConfig,
             RandomWaiter waiter,
             MultiFactorApiClient apiClient,
-            ILogger logger)
+            ILogger logger,
+            NameResolverService nameResolverService)
         {
             _clientConnection = clientConnection ?? throw new ArgumentNullException(nameof(clientConnection));
             _clientStream = clientStream ?? throw new ArgumentNullException(nameof(clientStream));
@@ -55,6 +59,7 @@ namespace MultiFactor.Ldap.Adapter.Server
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
             _ldapService = new LdapService();
+            _nameResolverService = nameResolverService;
         }
 
         public async Task Start()
@@ -177,7 +182,14 @@ namespace MultiFactor.Ldap.Adapter.Server
                         //apply login transformation rules if any
                         _userName = ProcessUserNameTransformRules();
 
-                        var profile = await _ldapService.LoadProfile(_serverStream, _userName);
+                        string baseDn = await _ldapService.GetBaseDn(_serverStream, _userName);
+
+                        if (_clientConfig.TransformLdapIdentity != LdapIdentityFormat.None)
+                        {
+                            _userName = await EnforceLdapIdentityFormat(baseDn, _clientConfig.TransformLdapIdentity);
+                        }
+
+                        var profile = await _ldapService.LoadProfile(_serverStream, baseDn, _userName);
 
                         if (_clientConfig.CheckUserGroups())
                         {
@@ -445,6 +457,30 @@ namespace MultiFactor.Ldap.Adapter.Server
             }
 
             return userName;
+        }
+
+        private async Task<string> EnforceLdapIdentityFormat(string baseDn, LdapIdentityFormat loginFormat)
+        {
+            if (loginFormat == LdapIdentityFormat.None)
+            {
+                throw new ArgumentException("Incorrect identity format was passed");
+            }
+
+            _logger.Debug($"{_userName} username will be transformed to {_clientConfig.TransformLdapIdentity} format"); ;
+            var domains = await _ldapService.GetDomains(_serverStream, baseDn);
+            var matchedProfile = await _ldapService.ResolveProfile(_serverStream, baseDn,_userName);
+            if (matchedProfile == null)
+            {
+                _logger.Error($"{_userName} profile was not found, unable to translate the username");
+                return _userName;
+            }
+            var context = new NameResolverContext()
+            {
+                Domains = domains,
+                Profile = matchedProfile
+            };
+
+            return _nameResolverService.Resolve(context, _userName, loginFormat);
         }
 
     }

--- a/MultiFactor.Ldap.Adapter/Server/LdapProxy.cs
+++ b/MultiFactor.Ldap.Adapter/Server/LdapProxy.cs
@@ -4,7 +4,7 @@
 
 using MultiFactor.Ldap.Adapter.Configuration;
 using MultiFactor.Ldap.Adapter.Core;
-using MultiFactor.Ldap.Adapter.Core.NameResolve;
+using MultiFactor.Ldap.Adapter.Core.NameResolving;
 using MultiFactor.Ldap.Adapter.Core.NameResolving;
 using MultiFactor.Ldap.Adapter.Server.Authentication;
 using MultiFactor.Ldap.Adapter.Services;

--- a/MultiFactor.Ldap.Adapter/Server/LdapProxyFactory.cs
+++ b/MultiFactor.Ldap.Adapter/Server/LdapProxyFactory.cs
@@ -3,6 +3,7 @@
 //https://github.com/MultifactorLab/MultiFactor.Ldap.Adapter/blob/main/LICENSE.md
 
 using MultiFactor.Ldap.Adapter.Configuration;
+using MultiFactor.Ldap.Adapter.Core.NameResolve;
 using MultiFactor.Ldap.Adapter.Services;
 using Serilog;
 using System;
@@ -16,12 +17,13 @@ namespace MultiFactor.Ldap.Adapter.Server
         private readonly RandomWaiter _waiter;
         private readonly MultiFactorApiClient _apiClient;
         private readonly ILogger _logger;
-
-        public LdapProxyFactory(RandomWaiter waiter, MultiFactorApiClient apiClient, ILogger logger)
+        private readonly NameResolverService _nameResolverService;
+        public LdapProxyFactory(RandomWaiter waiter, MultiFactorApiClient apiClient, ILogger logger, NameResolverService nameResolverService)
         {
             _waiter = waiter ?? throw new ArgumentNullException(nameof(waiter));
             _apiClient = apiClient ?? throw new ArgumentNullException(nameof(apiClient));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _nameResolverService = nameResolverService ?? throw new ArgumentNullException(nameof(_nameResolverService));
         }
 
         public LdapProxy CreateProxy(TcpClient clientConnection, Stream clientStream, 
@@ -32,7 +34,8 @@ namespace MultiFactor.Ldap.Adapter.Server
                 serverConnection, serverStream, 
                 clientConfig,
                 _waiter, _apiClient,
-                _logger);
+                _logger,
+                _nameResolverService);
         }
     }
 }

--- a/MultiFactor.Ldap.Adapter/Server/LdapProxyFactory.cs
+++ b/MultiFactor.Ldap.Adapter/Server/LdapProxyFactory.cs
@@ -3,7 +3,7 @@
 //https://github.com/MultifactorLab/MultiFactor.Ldap.Adapter/blob/main/LICENSE.md
 
 using MultiFactor.Ldap.Adapter.Configuration;
-using MultiFactor.Ldap.Adapter.Core.NameResolve;
+using MultiFactor.Ldap.Adapter.Core.NameResolving;
 using MultiFactor.Ldap.Adapter.Services;
 using Serilog;
 using System;


### PR DESCRIPTION
### Release 03.04.2024 | Transform a ldap Identity format to UPN
#### New
1.  New parameter \<add key="transform-ldap-identity" value="upn"/\>. Since the parameter is enabled, LDAP Adapter will make an additional request to load an extended profile information and will transform the identity had used to login into the upn format.